### PR TITLE
fix: ensure dist folder is built before npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,10 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         run: npm ci
 
+      - name: Build project
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm run build
+
       - name: Publish to NPM
         run: npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "unit": "npm run build-clean && node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "integration": "npm run build-clean && npx playwright test",
     "benchmark": "npm run build-clean && cd benchmarks && npm install && npm start",
-    "lint": "npx eslint src tests"
+    "lint": "npx eslint src tests",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",


### PR DESCRIPTION
## Problem

The latest npm release (v1.0.12) is missing the `dist` folder, making the package unusable since the main entry point is `dist/index.js`. This happened because:

1. The `dist` folder is in `.gitignore` (correctly)
2. The release workflow publishes to npm without building the project first
3. The `package.json` specifies `"files": ["dist"]` but the folder doesn't exist during publish

## Solution

This PR adds two layers of protection:

1. **Build step in release workflow**: Added `npm run build` step before publishing in `.github/workflows/release-please.yml`
2. **prepublishOnly script**: Added `"prepublishOnly": "npm run build"` to `package.json` as a safety net

## Testing

Tested with `npm publish --dry-run` which now correctly:
- Runs the `prepublishOnly` script
- Builds the `dist` folder
- Includes all 66 files (82.2 kB unpacked) in the package

## Impact

- Fixes the broken v1.0.12 npm package
- Prevents future releases from missing the `dist` folder
- No breaking changes to existing functionality